### PR TITLE
Check correct exception for "object not found"

### DIFF
--- a/BitPaySetup/Program.cs
+++ b/BitPaySetup/Program.cs
@@ -486,7 +486,7 @@ namespace BitPaySetup
             }
             catch (Exception e)
             {
-                if (e.Message.ToLower().Contains("object not found"))
+                if (e.InnerException.Message.ToLower().Contains("object not found"))
                 {
                     return true;
                 }


### PR DESCRIPTION
If outer exception is checked the token can never be verified and it's not possible to finish the configuration process.