### PR TITLE
#167 Update supported versions and readme

### DIFF
--- a/.dotnetexec.json
+++ b/.dotnetexec.json
@@ -3,10 +3,10 @@
   "entrypoint": "/bin/bash",
   "commands": {
     "setup": [
-      "dotnet run --project BitPaySetup --framework net7.0"
+      "dotnet run --project BitPaySetup --framework net8.0"
     ],
-    "setup-6": [
-      "dotnet run --project BitPaySetup --framework net6.0"
+    "setup-9": [
+      "dotnet run --project BitPaySetup --framework net9.0"
     ],
     "setup-48": [
       "dotnet run --project BitPaySetup --framework net48"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet-version: [ '6.0', '7.0', '8.0' ]
+        dotnet-version: [ '8.0', '9.0' ]
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install dependencies
@@ -26,9 +26,9 @@ jobs:
   build-and-test-48:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup MSBuild path
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v2
         with:
           dotNetVersion: '4.8.x'
       - name: Install dependencies

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        <TargetFrameworks>net48;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ To get up and running with our C# library quickly, follow [The GUIDE](https://bi
 
 ## .NET supported versions
 
-SDK | 5.x.x | 6.x.x
---- | --- | ---
-.NET Supported version | net48, 6.0, 7.0 | net48, 6.0, 7.0, 8.0
+net48, 8.0, 9.0
 
 ## Support
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0",
+    "version": "8.0.410",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
Since .NET 6 and 7 are EOL, we should only support 8 and 9 (as well as .NET Framework 4.8).