### PR TITLE
Add Release Build GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,19 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0'
+          
+      - name: Setup .NET 9.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0'
+      
+      - name: Setup MSBuild for .NET Framework 4.8
+        uses: microsoft/setup-msbuild@v2
+        with:
+          dotNetVersion: '4.8.x'
+      
+      - name: Restore dependencies
+        run: dotnet restore
       
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,23 +8,22 @@ on:
 jobs:
   build-release-package:
     runs-on: windows-2022
-    strategy:
-      fail-fast: false
-      matrix:
-        dotnet-version: ['8.0', '9.0', '48']
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup .NET ${{ matrix.dotnet-version }}
-        if: matrix.dotnet-version != '48'
+      - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-
+          dotnet-version: '8.0'
+          
+      - name: Setup .NET 9.0
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0'
+      
       - name: Setup MSBuild for .NET Framework 4.8
-        if: matrix.dotnet-version == '48'
         uses: microsoft/setup-msbuild@v3
 
       - name: Restore dependencies
@@ -33,8 +32,14 @@ jobs:
       - name: Build for all targets
         run: dotnet build --configuration Release --no-restore
 
-      - name: Run tests for ${{ matrix.dotnet-version }}
-        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net${{ matrix.dotnet-version }}
+      - name: Run tests for net8.0
+        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net8.0
+      
+      - name: Run tests for net9.0
+        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net9.0
+      
+      - name: Run tests for net48
+        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net48
 
       - name: Pack NuGet package
         run: dotnet pack BitPay/BitPay.csproj --configuration Release --no-build --output ./artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - published
 
 jobs:
-  build-release-package:
+  build:
     runs-on: windows-2022
     
     steps:
@@ -34,26 +34,75 @@ jobs:
       - name: Build for all targets
         run: dotnet build --configuration Release --no-restore
       
-      - name: Run tests for net8.0
-        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net8.0
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            **/bin/Release/**
+            !**/bin/Release/**/ref/**
+          retention-days: 1
+  
+  test:
+    needs: build
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: ['net8.0', 'net48']
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       
-      - name: Run tests for net9.0
-        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net9.0
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0'
       
-      - name: Run tests for net48
-        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net48
+      - name: Setup MSBuild for .NET Framework 4.8
+        if: matrix.framework == 'net48'
+        uses: microsoft/setup-msbuild@v2
+        with:
+          dotNetVersion: '4.8.x'
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+      
+      - name: Run tests for ${{ matrix.framework }}
+        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f ${{ matrix.framework }}
+  
+  package:
+    needs: test
+    runs-on: windows-2022
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0'
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
       
       - name: Pack NuGet package
         run: dotnet pack BitPay/BitPay.csproj --configuration Release --no-build --output ./artifacts
       
-      - name: Upload artifacts
+      - name: Upload NuGet package
         uses: actions/upload-artifact@v4
         with:
           name: bitpay-nuget-package
           path: ./artifacts/*.nupkg
           retention-days: 90
       
-      - name: Upload symbol packages
+      - name: Upload symbol package
         uses: actions/upload-artifact@v4
         with:
           name: bitpay-symbol-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,117 +6,48 @@ on:
       - published
 
 jobs:
-  build:
-    runs-on: windows-2022
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0'
-          
-      - name: Setup .NET 9.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '9.0'
-      
-      - name: Setup MSBuild for .NET Framework 4.8
-        uses: microsoft/setup-msbuild@v2
-        with:
-          dotNetVersion: '4.8.x'
-      
-      - name: Restore dependencies
-        run: dotnet restore
-      
-      - name: Build for all targets
-        run: dotnet build --configuration Release --no-restore
-      
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-output
-          path: |
-            **/bin/Release/**
-            !**/bin/Release/**/ref/**
-          retention-days: 1
-  
-  test:
-    needs: build
+  build-release-package:
     runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
-        framework: ['net8.0', 'net48']
-    
+        dotnet-version: ['8.0', '9.0', '48']
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/checkout@v6
+
+      - name: Setup .NET ${{ matrix.dotnet-version }}
+        if: matrix.dotnet-version != '48'
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0'
-      
+          dotnet-version: ${{ matrix.dotnet-version }}
+
       - name: Setup MSBuild for .NET Framework 4.8
-        if: matrix.framework == 'net48'
-        uses: microsoft/setup-msbuild@v2
-        with:
-          dotNetVersion: '4.8.x'
-      
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-output
-      
-      - name: Run tests for ${{ matrix.framework }}
-        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f ${{ matrix.framework }}
-  
-  package:
-    needs: test
-    runs-on: windows-2022
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0'
-          
-      - name: Setup .NET 9.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '9.0'
-      
-      - name: Setup MSBuild for .NET Framework 4.8
-        uses: microsoft/setup-msbuild@v2
-        with:
-          dotNetVersion: '4.8.x'
-      
+        if: matrix.dotnet-version == '48'
+        uses: microsoft/setup-msbuild@v3
+
       - name: Restore dependencies
         run: dotnet restore
-      
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-output
-      
+
+      - name: Build for all targets
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Run tests for ${{ matrix.dotnet-version }}
+        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net${{ matrix.dotnet-version }}
+
       - name: Pack NuGet package
         run: dotnet pack BitPay/BitPay.csproj --configuration Release --no-build --output ./artifacts
-      
+
       - name: Upload NuGet package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bitpay-nuget-package
           path: ./artifacts/*.nupkg
           retention-days: 90
-      
+
       - name: Upload symbol package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bitpay-symbol-package
           path: ./artifacts/*.snupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release Build
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-release-package:
+    runs-on: windows-2022
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0'
+          
+      - name: Setup .NET 9.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0'
+      
+      - name: Setup MSBuild for .NET Framework 4.8
+        uses: microsoft/setup-msbuild@v2
+        with:
+          dotNetVersion: '4.8.x'
+      
+      - name: Restore dependencies
+        run: dotnet restore
+      
+      - name: Build for all targets
+        run: dotnet build --configuration Release --no-restore
+      
+      - name: Run tests for net8.0
+        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net8.0
+      
+      - name: Run tests for net9.0
+        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net9.0
+      
+      - name: Run tests for net48
+        run: dotnet test BitPayUnitTest --configuration Release --no-build --verbosity normal -f net48
+      
+      - name: Pack NuGet package
+        run: dotnet pack BitPay/BitPay.csproj --configuration Release --no-build --output ./artifacts
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bitpay-nuget-package
+          path: ./artifacts/*.nupkg
+          retention-days: 90
+      
+      - name: Upload symbol packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: bitpay-symbol-package
+          path: ./artifacts/*.snupkg
+          retention-days: 90

--- a/BitPay/BitPay.csproj
+++ b/BitPay/BitPay.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <!-- version numbers will be updated by build -->
-    <AssemblyVersion>6.0.0.0</AssemblyVersion>
-    <FileVersion>6.0.0</FileVersion>
-    <VersionPrefix>6.0.0</VersionPrefix>
-    <Version>6.0.0</Version>
+    <AssemblyVersion>6.0.1.0</AssemblyVersion>
+    <FileVersion>6.0.1</FileVersion>
+    <VersionPrefix>6.0.1</VersionPrefix>
+    <Version>6.0.1</Version>
     <Authors>Antonio Buedo</Authors>
     <Company>BitPay Inc.</Company>
     <Owners>BitPay, Inc.</Owners>

--- a/BitPay/Config.cs
+++ b/BitPay/Config.cs
@@ -8,7 +8,7 @@ namespace BitPay
         public const string TestUrl = "https://test.bitpay.com/";
         public const string ProdUrl = "https://bitpay.com/";
         public const string BitPayApiVersion = "2.0.0";
-        public const string BitPayPluginInfo = "BitPay_DotNet_Client_v6.0.0";
+        public const string BitPayPluginInfo = "BitPay_DotNet_Client_v6.0.1";
         public const string BitPayApiFrame = "std";
         public const string BitPayApiFrameVersion = "1.0.0";
     }

--- a/BitPayUnitTest/BitPayUnitTest.csproj
+++ b/BitPayUnitTest/BitPayUnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
Adds a new GitHub Actions workflow that automatically builds and packages the BitPay NuGet package for release when a new GitHub release is published.

### What's Changed
- New workflow: release.yml
  - Triggered automatically when a GitHub release is published
  - Runs on Windows 2022 to support all target frameworks
- Bump version to 6.0.1

### Features

- Multi-target build: Compiles the library for all supported frameworks:
  - .NET Framework 4.8 (net48)
  - .NET 8.0 (net8.0)
  - .NET 9.0 (net9.0)
- Test validation: Runs unit tests across all supported test frameworks before packaging
- NuGet artifact creation:
  - Creates multi-targeted NuGet package (.nupkg) containing binaries for all frameworks
  - Generates symbol package (.snupkg) for debugging support
  - Uploads both as workflow artifacts with 90-day retention

### Usage

1. Create a new GitHub release from the Releases page
2. The workflow will automatically trigger and build the package
3. Download the NuGet package from the workflow run's artifacts

### Benefits
- Ensures consistent, reproducible builds for releases
- Validates all tests pass before packaging
- Provides downloadable artifacts for manual verification before publishing to NuGet.org
- Single package contains all target framework versions